### PR TITLE
fix(backend): 修复搜索结果列表展示中摘要返回全文的问题

### DIFF
--- a/backend/Readme.md
+++ b/backend/Readme.md
@@ -22,6 +22,9 @@ springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.default-consumes-media-type=application/json
 springdoc.default-produces-media-type=application/json
+#-----FOR DEBUGGING-----#
+#logging.level.tracer=TRACE
+#-----------------------#
 ```
 
 ### 编译运行

--- a/backend/src/main/java/team/semg04/themirroroflaw/search/SearchController.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/search/SearchController.java
@@ -35,7 +35,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import team.semg04.themirroroflaw.Response;
-import team.semg04.themirroroflaw.search.laws.LawsData;
+import team.semg04.themirroroflaw.search.data.LawsData;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -86,8 +86,7 @@ public class SearchController {
             Pageable pageable = Pageable.ofSize(pageSize).withPage(pageNumber);
             HighlightParameters highlightParameters =
                     HighlightParameters.builder().withBoundaryScannerLocale("zh-cn").withBoundaryChars(".,!?; " +
-                                    "\t\n，。！？；")
-                            .withPreTags("<span style=\"color: #ff0000\">").withPostTags("</span>").build();
+                            "\t\n，。！？；").withPreTags("").withPostTags("").build();
             for (ResultType type : filters.getResultType()) {
                 if (type == ResultType.LAW) {
                     String fields = switch (searchType) {

--- a/backend/src/main/java/team/semg04/themirroroflaw/search/data/LawsData.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/search/data/LawsData.java
@@ -1,4 +1,4 @@
-package team.semg04.themirroroflaw.search.laws;
+package team.semg04.themirroroflaw.search.data;
 
 import lombok.Data;
 import org.springframework.data.annotation.Id;

--- a/backend/src/main/resources/application_template.properties
+++ b/backend/src/main/resources/application_template.properties
@@ -10,3 +10,6 @@ springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.default-consumes-media-type=application/json
 springdoc.default-produces-media-type=application/json
+#-----FOR DEBUGGING-----#
+#logging.level.tracer=TRACE
+#-----------------------#


### PR DESCRIPTION
1. 修复搜索结果列表展示中摘要返回全文的问题，目前的行为是：若搜索类型为Content则返回搜索结果上下文（使用<span style="color: #ff0000">标记），否则返回前100字
2. 重构StringQuery为NativeQuery，一方面是利于添加高亮查询，另一方面是降低字符串拼接导致的注入风险