### PR TITLE
feat(backend): 实现知识图谱获取与新增接口

### DIFF
--- a/backend/src/main/java/team/semg04/themirroroflaw/SpringSecurityConfig.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/SpringSecurityConfig.java
@@ -71,6 +71,7 @@ public class SpringSecurityConfig {
                         .requestMatchers("/api/user/register").permitAll()
                         .requestMatchers("/api/search/**").permitAll()
                         .requestMatchers("/api/ai/**").permitAll()
+                        .requestMatchers("/api/graph/**").permitAll()
                         .requestMatchers("/swagger-ui/**").permitAll()
                         .requestMatchers("api-docs/**").permitAll()
                         .anyRequest().authenticated()

--- a/backend/src/main/java/team/semg04/themirroroflaw/graph/GraphController.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/graph/GraphController.java
@@ -40,10 +40,8 @@ public class GraphController {
         try {
             // check if all neighbors exist
             for (Long neighbor : graphNode.getNeighbors()) {
-                try {
-                    graphService.getById(neighbor);
-                } catch (Exception e) {
-                    log.warn("Graph node add error: ", e);
+                Graph graph = graphService.getById(neighbor);
+                if (graph == null) {
                     return new ResponseEntity<>(new Response<>(false, null, HttpStatus.BAD_REQUEST.value(),
                             "Neighbor not found."), HttpStatus.BAD_REQUEST);
                 }
@@ -144,7 +142,6 @@ public class GraphController {
 
     @Data
     public static class GraphNodeInfo {
-        Long id;
         String value;
         String description;
         List<Long> neighbors;

--- a/backend/src/main/java/team/semg04/themirroroflaw/graph/GraphController.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/graph/GraphController.java
@@ -1,0 +1,152 @@
+package team.semg04.themirroroflaw.graph;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import team.semg04.themirroroflaw.Response;
+import team.semg04.themirroroflaw.graph.entity.Graph;
+import team.semg04.themirroroflaw.graph.service.GraphService;
+
+import java.util.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/graph")
+@Tag(name = "Graph", description = "知识图谱")
+public class GraphController {
+    private final GraphService graphService;
+
+    @Autowired
+    public GraphController(GraphService graphService) {
+        this.graphService = graphService;
+    }
+
+    @Operation(summary = "新增节点", description = "新增节点。")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "成功"),
+            @ApiResponse(responseCode = "400", description = "邻居不存在"),
+            @ApiResponse(responseCode = "500", description = "服务器内部错误")
+    })
+    @PostMapping("/add")
+    public ResponseEntity<Response<Void>> add(@RequestBody GraphNodeInfo graphNode) {
+        try {
+            // check if all neighbors exist
+            for (Long neighbor : graphNode.getNeighbors()) {
+                try {
+                    graphService.getById(neighbor);
+                } catch (Exception e) {
+                    log.warn("Graph node add error: ", e);
+                    return new ResponseEntity<>(new Response<>(false, null, HttpStatus.BAD_REQUEST.value(),
+                            "Neighbor not found."), HttpStatus.BAD_REQUEST);
+                }
+            }
+
+            // save current node
+            Graph graph = new Graph(0L, graphNode.getValue(), graphNode.getDescription(), null);
+            graph.setNeighborsFromList(graphNode.getNeighbors());
+            graphService.save(graph);
+
+            // save neighbors
+            for (Long neighbor : graphNode.getNeighbors()) {
+                Graph neighborNode = graphService.getById(neighbor);
+                List<Long> neighborNeighbors = neighborNode.getNeighborsAsList();
+                neighborNeighbors.add(graph.getId());
+                neighborNode.setNeighborsFromList(neighborNeighbors);
+                graphService.updateById(neighborNode);
+            }
+
+            log.debug("Graph node added: {}", graphNode);
+            return new ResponseEntity<>(new Response<>(true, null, 0, ""), HttpStatus.CREATED);
+        } catch (Exception e) {
+            log.error("Graph node add error: ", e);
+            return new ResponseEntity<>(new Response<>(false, null, HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                    "Internal server error."), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Operation(summary = "获取知识图谱结构", description = "⽤⼾每次进⾏搜索，或者点击切换知识图谱中的中⼼节点，都需要获取新的知识图谱结构，以\n" +
+            "渲染出新的知识图谱。其中，若为每次搜索后⾃动产⽣的知识图谱，则其中⼼词由输⼊内容分析得出。")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "成功"),
+            @ApiResponse(responseCode = "500", description = "服务器内部错误")
+    })
+    @GetMapping("/get")
+    public ResponseEntity<Response<ResponseGraph>> get(@RequestParam String input, @RequestParam Integer depth) {
+        try {
+            Graph graph = graphService.getByValue(input);
+            if (graph == null) {
+                return new ResponseEntity<>(new Response<>(false, null, HttpStatus.NOT_FOUND.value(), "Center not " +
+                        "found."), HttpStatus.NOT_FOUND);
+            }
+
+            ResponseNodeInfo center = new ResponseNodeInfo(graph.getId(), graph.getValue(), null);
+            ResponseGraph responseGraph = new ResponseGraph(center, graph.getDescription());
+            Set<Long> visited = new HashSet<>();
+
+            // BFS
+            Queue<ResponseNodeInfo> curQueue = new LinkedList<>();
+            Queue<ResponseNodeInfo> nextQueue = new LinkedList<>();
+            curQueue.add(center);
+            visited.add(center.getId());
+            for (int i = 0; i < depth; i++) {
+                while (!curQueue.isEmpty()) {
+                    ResponseNodeInfo curNode = curQueue.poll();
+
+                    List<Long> neighbors = graphService.getById(curNode.getId()).getNeighborsAsList();
+                    List<ResponseNodeInfo> children = new ArrayList<>();
+                    for (Long neighbor : neighbors) {
+                        if (!visited.contains(neighbor)) {
+                            visited.add(neighbor);
+                            Graph neighborNode = graphService.getById(neighbor);
+                            ResponseNodeInfo child = new ResponseNodeInfo(neighborNode.getId(),
+                                    neighborNode.getValue(), null);
+                            children.add(child);
+                            nextQueue.add(child);
+                        }
+                    }
+                    curNode.setChildren(children);
+                }
+                curQueue = nextQueue;
+                nextQueue = new LinkedList<>();
+            }
+
+            log.debug("Graph get: {}", responseGraph);
+            return new ResponseEntity<>(new Response<>(true, responseGraph, 0, ""), HttpStatus.OK);
+        } catch (Exception e) {
+            log.error("Graph node get error: ", e);
+            return new ResponseEntity<>(new Response<>(false, null, HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                    "Internal server error."), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class ResponseNodeInfo {
+        Long id;
+        String value;
+        List<ResponseNodeInfo> children;
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class ResponseGraph {
+        ResponseNodeInfo center;
+        String desc;
+    }
+
+    @Data
+    public static class GraphNodeInfo {
+        Long id;
+        String value;
+        String description;
+        List<Long> neighbors;
+    }
+}

--- a/backend/src/main/java/team/semg04/themirroroflaw/graph/entity/Graph.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/graph/entity/Graph.java
@@ -1,0 +1,43 @@
+package team.semg04.themirroroflaw.graph.entity;
+
+import com.alibaba.fastjson.JSONArray;
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
+@Data
+@Slf4j
+@AllArgsConstructor
+@TableName("graphs")
+public class Graph {
+    @TableId(value = "id", type = IdType.AUTO)
+    Long id;
+    String value;
+    String description;
+    byte[] neighbors;
+
+    public List<Long> getNeighborsAsList() {
+        try {
+            List list = new ObjectMapper().readValue(new String(neighbors), List.class);
+            return JSONArray.parseArray(list.toString(), Long.class);
+        } catch (Exception e) {
+            log.error("Graph node getNeighbors error: ", e);
+            return null;
+        }
+    }
+
+    public void setNeighborsFromList(List<Long> neighbors) {
+        try {
+            this.neighbors = new ObjectMapper().writeValueAsString(neighbors).getBytes();
+        } catch (Exception e) {
+            log.error("Graph node setNeighbors error: ", e);
+            this.neighbors = null;
+        }
+    }
+}

--- a/backend/src/main/java/team/semg04/themirroroflaw/graph/mapper/GraphMapper.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/graph/mapper/GraphMapper.java
@@ -1,0 +1,9 @@
+package team.semg04.themirroroflaw.graph.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.annotations.Mapper;
+import team.semg04.themirroroflaw.graph.entity.Graph;
+
+@Mapper
+public interface GraphMapper extends BaseMapper<Graph> {
+}

--- a/backend/src/main/java/team/semg04/themirroroflaw/graph/service/GraphService.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/graph/service/GraphService.java
@@ -1,0 +1,8 @@
+package team.semg04.themirroroflaw.graph.service;
+
+import com.baomidou.mybatisplus.extension.service.IService;
+import team.semg04.themirroroflaw.graph.entity.Graph;
+
+public interface GraphService extends IService<Graph> {
+    Graph getByValue(String value);
+}

--- a/backend/src/main/java/team/semg04/themirroroflaw/graph/service/GraphServiceImpl.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/graph/service/GraphServiceImpl.java
@@ -1,0 +1,16 @@
+package team.semg04.themirroroflaw.graph.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import org.springframework.stereotype.Service;
+import team.semg04.themirroroflaw.graph.entity.Graph;
+import team.semg04.themirroroflaw.graph.mapper.GraphMapper;
+
+@Service
+public class GraphServiceImpl extends ServiceImpl<GraphMapper, Graph> implements GraphService {
+    public Graph getByValue(String value) {
+        QueryWrapper<Graph> queryWrapper = new QueryWrapper<>();
+        queryWrapper.eq("value", value);
+        return getOne(queryWrapper);
+    }
+}

--- a/backend/src/main/java/team/semg04/themirroroflaw/user/UserController.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/user/UserController.java
@@ -66,7 +66,7 @@ public class UserController {
             @Schema(implementation = Response.class)))
     })
     @PostMapping("/register")
-    public ResponseEntity<Response<String>> register(@RequestBody UserRegister userRegister) {
+    public ResponseEntity<Response<Void>> register(@RequestBody UserRegister userRegister) {
         try {
             if (!validateUsername(userRegister.getUserName())) {
                 log.error("User register error: Username not valid. Username: " + userRegister.getUserName());


### PR DESCRIPTION
对知识图谱存储做了重新设计，实体Graph结构如下：
|Column|Type|Note|
|---|---|---|
|id|BIGINT|主键|
|value|VARCHAR|节点名称|
|description|VARCHAR|节点描述|
|neighbors|BLOB|邻居，为List<Long>序列化后的结果，存储邻居的id列表|

为方便后续向数据库中添加数据，设计了新增节点的接口： POST /api/graph/add
参数如下：
```json
{
	"value": "String",
	"description": "String",
	"neighbors": "List<Long>"
}
```
---

针对获取知识图谱的接口，目前仅支持能在数据库中查找到某个节点value等于input的情况，未来可能需要考虑如何在数据库中查找到与input最接近的那个节点作为中心节点。

---
以下为原commit信息：

1. 实现知识图谱获取与新增的接口。
2. 新增知识图谱相关实体类、服务类等，重新设计知识图谱表结构。
3. 修复用户注册接口返回类型不正确的bug。