### PR TITLE
实现词云数据获取与AI文档总结接口

### DIFF
--- a/backend/src/main/java/team/semg04/themirroroflaw/SpringSecurityConfig.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/SpringSecurityConfig.java
@@ -71,6 +71,7 @@ public class SpringSecurityConfig {
                         .requestMatchers("/api/user/register").permitAll()
                         .requestMatchers("/api/search/**").permitAll()
                         .requestMatchers("/api/ai/**").permitAll()
+                        .requestMatchers("/api/word-cloud/**").permitAll()
                         .requestMatchers("/api/graph/**").permitAll()
                         .requestMatchers("/swagger-ui/**").permitAll()
                         .requestMatchers("api-docs/**").permitAll()

--- a/backend/src/main/java/team/semg04/themirroroflaw/ai/AIController.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/ai/AIController.java
@@ -9,6 +9,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +18,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import team.semg04.themirroroflaw.Response;
+import team.semg04.themirroroflaw.search.SearchController;
+import team.semg04.themirroroflaw.search.entity.Laws;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -24,8 +30,16 @@ import team.semg04.themirroroflaw.Response;
 public class AIController {
 
     private static final String extractPrompt = "请从我下面所给出的这段文字中，提取3~5个关键词，并且尽可能使用法律领域相关的专有名词或术语，" +
-            "用于优化其在搜索引擎中的检索效果。你的回答不应包含任何多余的内容，只需要将这些关键词通过';'进行分割作为回复即可，例如'故意伤人;宪法;无期徒刑'。\n" +
-            "文字内容：";
+            "用于优化其在搜索引擎中的检索效果。你的回答不应包含任何多余的内容，只需要将这些关键词通过';'进行分割作为回复即可，例如'故意伤人;宪法;无期徒刑'," +
+            "且回答内容应与文字内容贴合。\n" + "文字内容：";
+    private static final String summarizePrompt = "请对我下面所给出的这段文字进行总结，在尽可能保留大意的情况下，将其总结为不超过300字的摘要," +
+            "你的回答应当只包含总结的内容，而不该出现‘好的’、‘收到’等无意义的回应：\n";
+
+    private ElasticsearchOperations elasticsearchOperations;
+    @Autowired
+    public void setElasticsearchOperations(ElasticsearchOperations elasticsearchOperations) {
+        this.elasticsearchOperations = elasticsearchOperations;
+    }
 
     @Operation(summary = "关键词提取", description = "用户输入一段文字，返回这段文字中提取出的若干关键词")
     @Parameters({
@@ -39,7 +53,7 @@ public class AIController {
             @Schema(implementation = Response.class)))
     })
     @GetMapping("/extract")
-    public ResponseEntity<Response<String>> userInfo(@RequestParam(name = "input") String input) {
+    public ResponseEntity<Response<String>> extractKeyword(@RequestParam(name = "input") String input) {
         String result;
         try {
             result = SparkModelConnector.getAnswer(extractPrompt + input);
@@ -49,6 +63,54 @@ public class AIController {
             return new ResponseEntity<>(new Response<>(false, null, HttpStatus.INTERNAL_SERVER_ERROR.value(),
                     "Internal server error."), HttpStatus.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    @Operation(summary = "文档总结", description = "对当前⽂档内容进⾏总结，⽣成⼀段⽂字概要（考虑对不同类型的⽂章⽣成合适的概要形式）")
+    @Parameters({
+            @Parameter(name = "id", description = "文档id"),
+            @Parameter(name = "type", description = "文档类型")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "成功"),
+            @ApiResponse(responseCode = "400", description = "请求参数错误", content = @Content(schema =
+            @Schema(implementation = Response.class))),
+            @ApiResponse(responseCode = "404", description = "内容不存在", content = @Content(schema =
+            @Schema(implementation = Response.class))),
+            @ApiResponse(responseCode = "500", description = "服务器内部错误", content = @Content(schema =
+            @Schema(implementation = Response.class)))
+    })
+    @GetMapping("/summarize")
+    public ResponseEntity<Response<String>> summarizeInfo(@RequestParam(name = "id") String id, @RequestParam(name = "type") Integer typeInt) {
+        String result = null;
+        try {
+            if(typeInt == DocumentType.LAW.ordinal()) {
+                Laws laws = elasticsearchOperations.get(id, Laws.class);
+                if (laws == null) {
+                    log.error("Get search result detail error: LawsData not found. Id: " + id);
+                    return new ResponseEntity<>(new Response<>(false, null, HttpStatus.NOT_FOUND.value(),
+                            "LawsData not found."), HttpStatus.NOT_FOUND);
+                }
+                if (laws.getContent().length() >= 4096 - summarizePrompt.length()) {
+                    return new ResponseEntity<>(new Response<>(false, null, HttpStatus.BAD_REQUEST.value(),
+                            "Request document too long."), HttpStatus.BAD_REQUEST);
+                }
+                result = SparkModelConnector.getAnswer(summarizePrompt + laws.getContent());
+                if (result.isEmpty())
+                    return new ResponseEntity<>(new Response<>(false, null, HttpStatus.BAD_REQUEST.value(),
+                            "Include sensitive contents."), HttpStatus.BAD_REQUEST);
+            } else if (typeInt == SearchController.ResultType.JUDGEMENT.ordinal()) {
+                return new ResponseEntity<>(new Response<>(false, null, HttpStatus.BAD_REQUEST.value(), "Not " +
+                        "implemented."), HttpStatus.BAD_REQUEST);
+            }
+            return new ResponseEntity<>(new Response<>(true, result, 0, ""), HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(new Response<>(false, null, HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                    "Internal server error."), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public enum DocumentType {
+        LAW, JUDGEMENT
     }
 
 }

--- a/backend/src/main/java/team/semg04/themirroroflaw/ai/SparkModelConnector.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/ai/SparkModelConnector.java
@@ -148,6 +148,7 @@ public class SparkModelConnector extends WebSocketListener {
             System.out.println("发生错误，错误码为：" + myJsonParse.header.code);
             System.out.println("本次请求的sid为：" + myJsonParse.header.sid);
             webSocket.close(1000, "");
+            totalFlag = true;
         }
         List<Text> textList = myJsonParse.payload.choices.text;
         for (Text temp : textList) {

--- a/backend/src/main/java/team/semg04/themirroroflaw/search/LawFrequencyAnalyzer.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/search/LawFrequencyAnalyzer.java
@@ -12,7 +12,7 @@ public class LawFrequencyAnalyzer {
 
     public static List<Map<String, Object>> getAnalyzedJson(String text) {
         final FrequencyAnalyzer frequencyAnalyzer = new FrequencyAnalyzer();
-        frequencyAnalyzer.setWordFrequenciesToReturn(600);
+        frequencyAnalyzer.setWordFrequenciesToReturn(100);
         frequencyAnalyzer.setMinWordLength(2);
         frequencyAnalyzer.setWordTokenizer(new ChineseWordTokenizer());
         List<WordFrequency> wordFrequencies = frequencyAnalyzer.load(List.of(text));

--- a/backend/src/main/java/team/semg04/themirroroflaw/search/WordFrequencyController.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/search/WordFrequencyController.java
@@ -1,0 +1,80 @@
+package team.semg04.themirroroflaw.search;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import team.semg04.themirroroflaw.Response;
+import team.semg04.themirroroflaw.search.entity.Laws;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/word-cloud")
+@Tag(name = "wordCloud", description = "词频分析接口")
+public class WordFrequencyController {
+    private ElasticsearchOperations elasticsearchOperations;
+    @Autowired
+    public void setElasticsearchOperations(ElasticsearchOperations elasticsearchOperations) {
+        this.elasticsearchOperations = elasticsearchOperations;
+    }
+
+    @Operation(summary = "获取词云图信息", description = "前端发送请求获取该文档的一些关键词信息（关键词名称及权重）")
+    @Parameters({
+            @Parameter(name = "id", description = "文档id"),
+            @Parameter(name = "type", description = "文档类型")
+    })
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "成功"),
+            @ApiResponse(responseCode = "400", description = "请求参数错误", content = @Content(schema =
+            @Schema(implementation = Response.class))),
+            @ApiResponse(responseCode = "404", description = "内容不存在", content = @Content(schema =
+            @Schema(implementation = Response.class))),
+            @ApiResponse(responseCode = "500", description = "服务器内部错误", content = @Content(schema =
+            @Schema(implementation = Response.class)))
+    })
+    @GetMapping("/get")
+    public ResponseEntity<Response<List<Map<String, Object>> >> summarizeInfo(@RequestParam(name = "id") String id, @RequestParam(name = "type") Integer typeInt) {
+        List<Map<String, Object>> wordFrequencyList = new ArrayList<>();
+        try {
+            if(typeInt == DocumentType.LAW.ordinal()) {
+                Laws laws = elasticsearchOperations.get(id, Laws.class);
+                if (laws == null) {
+                    log.error("Get search result detail error: LawsData not found. Id: " + id);
+                    return new ResponseEntity<>(new Response<>(false, null, HttpStatus.NOT_FOUND.value(),
+                            "LawsData not found."), HttpStatus.NOT_FOUND);
+                }
+                wordFrequencyList = LawFrequencyAnalyzer.getAnalyzedJson(laws.getContent());
+            } else if (typeInt == SearchController.ResultType.JUDGEMENT.ordinal()) {
+                return new ResponseEntity<>(new Response<>(false, null, HttpStatus.BAD_REQUEST.value(), "Not " +
+                        "implemented."), HttpStatus.BAD_REQUEST);
+            }
+            return new ResponseEntity<>(new Response<>(true, wordFrequencyList, 0, ""), HttpStatus.OK);
+
+        } catch (Exception e) {
+            return new ResponseEntity<>(new Response<>(false, null, HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                    "Internal server error."), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public enum DocumentType {
+        LAW, JUDGEMENT
+    }
+
+}


### PR DESCRIPTION
1. 实现词云数据获取接口，返回文档高频的100词及频率
2. 实现AI文档总结接口，对于过长文本、敏感内容设置对应报错信息
3. 在安全配置中取消了对于词云数据获取接口的保护