### PR TITLE
feat(backend): 实现搜索历史与用户反馈接口

### DIFF
--- a/backend/Readme.md
+++ b/backend/Readme.md
@@ -46,7 +46,7 @@ springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.default-consumes-media-type=application/json
 springdoc.default-produces-media-type=application/json
 #-----FOR DEBUGGING-----#
-#logging.level.tracer=TRACE
+logging.level.team.semg04.themirroroflaw=DEBUG
 #-----------------------#
 ```
 

--- a/backend/src/main/java/team/semg04/themirroroflaw/graph/GraphController.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/graph/GraphController.java
@@ -82,6 +82,7 @@ public class GraphController {
         try {
             Graph graph = graphService.getByValue(input);
             if (graph == null) {
+                log.warn("Graph not found: {}", input);
                 return new ResponseEntity<>(new Response<>(false, null, HttpStatus.NOT_FOUND.value(), "Center not " +
                         "found."), HttpStatus.NOT_FOUND);
             }
@@ -95,7 +96,7 @@ public class GraphController {
             Queue<ResponseNodeInfo> nextQueue = new LinkedList<>();
             curQueue.add(center);
             visited.add(graph.getId());
-            for (int i = 0; i < depth; i++) {
+            for (int i = 0; i < depth && !curQueue.isEmpty(); i++) {
                 while (!curQueue.isEmpty()) {
                     ResponseNodeInfo curNode = curQueue.poll();
 
@@ -111,7 +112,9 @@ public class GraphController {
                             nextQueue.add(child);
                         }
                     }
-                    curNode.setChildren(children);
+                    if (!children.isEmpty()) {
+                        curNode.setChildren(children);
+                    }
                 }
                 curQueue = nextQueue;
                 nextQueue = new LinkedList<>();

--- a/backend/src/main/java/team/semg04/themirroroflaw/search/SearchController.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/search/SearchController.java
@@ -409,6 +409,14 @@ public class SearchController {
                     List<String> like = user.getLikeAsList();
                     like.remove(feedback.getId());
                     user.setLikeFromList(like);
+                } else if (user.getDislikeAsList().contains(feedback.getId())) {
+                    feedbackType = FeedbackType.DISLIKE_TO_LIKE;
+                    List<String> dislike = user.getDislikeAsList();
+                    dislike.remove(feedback.getId());
+                    user.setDislikeFromList(dislike);
+                    List<String> like = user.getLikeAsList();
+                    like.add(feedback.getId());
+                    user.setLikeFromList(like);
                 } else {
                     feedbackType = FeedbackType.LIKE;
                     List<String> like = user.getLikeAsList();
@@ -420,6 +428,14 @@ public class SearchController {
                     feedbackType = FeedbackType.CANCEL_DISLIKE;
                     List<String> dislike = user.getDislikeAsList();
                     dislike.remove(feedback.getId());
+                    user.setDislikeFromList(dislike);
+                } else if (user.getLikeAsList().contains(feedback.getId())) {
+                    feedbackType = FeedbackType.LIKE_TO_DISLIKE;
+                    List<String> like = user.getLikeAsList();
+                    like.remove(feedback.getId());
+                    user.setLikeFromList(like);
+                    List<String> dislike = user.getDislikeAsList();
+                    dislike.add(feedback.getId());
                     user.setDislikeFromList(dislike);
                 } else {
                     feedbackType = FeedbackType.DISLIKE;
@@ -443,6 +459,14 @@ public class SearchController {
                     case DISLIKE -> laws.setDislike(laws.getDislike() + 1);
                     case CANCEL_LIKE -> laws.setLike(laws.getLike() - 1);
                     case CANCEL_DISLIKE -> laws.setDislike(laws.getDislike() - 1);
+                    case LIKE_TO_DISLIKE -> {
+                        laws.setLike(laws.getLike() - 1);
+                        laws.setDislike(laws.getDislike() + 1);
+                    }
+                    case DISLIKE_TO_LIKE -> {
+                        laws.setLike(laws.getLike() + 1);
+                        laws.setDislike(laws.getDislike() - 1);
+                    }
                 }
                 elasticsearchOperations.save(laws);
                 log.debug("Feedback success. Id: " + feedback.getId());
@@ -470,7 +494,7 @@ public class SearchController {
     }
 
     public enum FeedbackType {
-        LIKE, DISLIKE, CANCEL_LIKE, CANCEL_DISLIKE
+        LIKE, DISLIKE, CANCEL_LIKE, CANCEL_DISLIKE, LIKE_TO_DISLIKE, DISLIKE_TO_LIKE
     }
 
     @Data

--- a/backend/src/main/java/team/semg04/themirroroflaw/search/SearchController.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/search/SearchController.java
@@ -8,6 +8,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,19 +21,21 @@ import org.springframework.data.elasticsearch.core.query.SearchTemplateQuery;
 import org.springframework.data.elasticsearch.core.script.Script;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import team.semg04.themirroroflaw.Response;
 import team.semg04.themirroroflaw.search.entity.Laws;
+import team.semg04.themirroroflaw.user.entity.User;
+import team.semg04.themirroroflaw.user.service.UserService;
+import team.semg04.themirroroflaw.user.utils.RememberMeService;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
 import static java.lang.System.exit;
+import static team.semg04.themirroroflaw.user.UserController.getCurrentUser;
 
 @Slf4j
 @RestController
@@ -40,6 +44,19 @@ import static java.lang.System.exit;
 public class SearchController {
 
     private ElasticsearchOperations elasticsearchOperations;
+    private UserService userService;
+
+    private RememberMeService rememberMeService;
+
+    @Autowired
+    public void setUserService(UserService userService) {
+        this.userService = userService;
+    }
+
+    @Autowired
+    public void setRememberMeService(RememberMeService rememberMeService) {
+        this.rememberMeService = rememberMeService;
+    }
 
     @Autowired
     public void setElasticsearchOperations(ElasticsearchOperations elasticsearchOperations) {
@@ -148,20 +165,20 @@ public class SearchController {
                         }""").build();
         try {
             elasticsearchOperations.deleteScript("search_by_all");
-            log.info("Delete script success.");
+            log.debug("Delete script success.");
         } catch (Exception e) {
             log.error("Delete script error: " + e.getMessage());
         }
         try {
             elasticsearchOperations.deleteScript("search_by_single");
-            log.info("Delete script success.");
+            log.debug("Delete script success.");
         } catch (Exception e) {
             log.error("Delete script error: " + e.getMessage());
         }
         try {
             elasticsearchOperations.putScript(allScript);
             elasticsearchOperations.putScript(singleScript);
-            log.info("Put script success.");
+            log.debug("Put script success.");
         } catch (Exception e) {
             log.error("Put script error: " + e.getMessage());
             exit(-1);
@@ -198,16 +215,17 @@ public class SearchController {
                                                            @RequestParam(name = "pageSize", required = false,
                                                                    defaultValue = "10") Integer pageSize,
                                                            @RequestParam(name = "pageNumber", required = false,
-                                                                   defaultValue = "0") Integer pageNumber) {
+                                                                   defaultValue = "0") Integer pageNumber,
+                                                           HttpServletRequest request, HttpServletResponse response) {
         try {
             // Check parameters
             if (pageSize <= 0 || pageSize > 50) {
-                log.error("Get search result list error: Invalid pageSize. pageSize: " + pageSize);
+                log.warn("Get search result list error: Invalid pageSize. pageSize: " + pageSize);
                 return new ResponseEntity<>(new Response<>(false, null, HttpStatus.BAD_REQUEST.value(),
                         "Invalid pageSize. PageSize should be in range [1, 50]."), HttpStatus.BAD_REQUEST);
             }
             if (pageNumber < 0 || pageNumber + pageSize > 10000) {
-                log.error("Get search result list error: Invalid pageNumber. pageNumber: " + pageNumber);
+                log.warn("Get search result list error: Invalid pageNumber. pageNumber: " + pageNumber);
                 return new ResponseEntity<>(new Response<>(false, null, HttpStatus.BAD_REQUEST.value(),
                         "Invalid pageNumber. PageNumber should be in range [0, 10000 - pageSize]."),
                         HttpStatus.BAD_REQUEST);
@@ -268,14 +286,44 @@ public class SearchController {
                         resultItem.setFeedbackCnt(new FeedbackCnt());
                         resultItem.getFeedbackCnt().setLikes(data.getContent().getLike());
                         resultItem.getFeedbackCnt().setDislikes(data.getContent().getDislike());
+                        resultItem.setScore(data.getScore());
                         searchList.getResults().add(resultItem);
                     }
                 } else if (typeInt == ResultType.JUDGEMENT.ordinal()) {
+                    log.warn("Get search result list error: Not implemented. Type: " + typeInt);
                     return new ResponseEntity<>(new Response<>(false, null, HttpStatus.BAD_REQUEST.value(), "Not " +
                             "implemented."), HttpStatus.BAD_REQUEST);
                 }
             }
-            log.info("Get search result list success. Total: " + searchList.getTotal());
+
+            // Sort result list and get the first pageSize items
+            // if score is the same, sort by date
+            searchList.getResults().sort((o1, o2) -> {
+                if (o1.getScore().equals(o2.getScore())) {
+                    return o2.getDate().compareTo(o1.getDate());
+                } else {
+                    return o2.getScore().compareTo(o1.getScore());
+                }
+            });
+            searchList.setResults(searchList.getResults().subList(0, Math.min(searchList.getResults().size(),
+                    pageSize)));
+
+            // add input into user history
+            User user = null;
+            try {
+                user = getCurrentUser(request, response, userService, rememberMeService);
+            } catch (Exception e) {
+                log.debug("Get personal history error: User not found." + e.getMessage());
+            }
+            if (user != null) {
+                LinkedHashSet<String> history = user.getHistoryAsSet();
+                history.add(input);
+                user.setHistoryFromSet(history);
+                userService.updateById(user);
+                log.debug("Add input into user history success. Input: " + input);
+            }
+
+            log.debug("Get search result list success. Total: " + searchList.getTotal());
             return new ResponseEntity<>(new Response<>(true, searchList, 0, ""), HttpStatus.OK);
         } catch (Exception e) {
             log.error("Get search result list error: " + e.getMessage());
@@ -286,7 +334,8 @@ public class SearchController {
 
     @Operation(summary = "结果详情展示", description = "用户点击搜索结果列表中的某一条后，即可进入详情页查看详细内容，这些内容应以合适的格式整理并呈现。")
     @Parameters({
-            @Parameter(name = "id", description = "内容的id")
+            @Parameter(name = "id", description = "内容的id"),
+            @Parameter(name = "type", description = "内容的类型")
     })
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "成功"),
@@ -296,28 +345,117 @@ public class SearchController {
             @Schema(implementation = Response.class)))
     })
     @GetMapping("/detail")
-    public ResponseEntity<Response<Detail>> searchDetail(@RequestParam(name = "id") String id) {
+    public ResponseEntity<Response<Detail>> searchDetail(@RequestParam(name = "id") String id,
+                                                         @RequestParam Integer type) {
         try {
             Detail detail = new Detail();
-            Laws laws = elasticsearchOperations.get(id, Laws.class);
-            if (laws == null) {
-                log.error("Get search result detail error: LawsData not found. Id: " + id);
-                return new ResponseEntity<>(new Response<>(false, null, HttpStatus.NOT_FOUND.value(),
-                        "LawsData not found."), HttpStatus.NOT_FOUND);
+            if (type == ResultType.LAW.ordinal()) {
+                Laws laws = elasticsearchOperations.get(id, Laws.class);
+                if (laws == null) {
+                    log.warn("Get search result detail error: LawsData not found. Id: " + id);
+                    return new ResponseEntity<>(new Response<>(false, null, HttpStatus.NOT_FOUND.value(),
+                            "LawsData not found."), HttpStatus.NOT_FOUND);
+                }
+                detail.setTitle(laws.getTitle());
+                detail.setSource(laws.getOffice());
+                detail.setPublishTime(laws.getPublish());
+                detail.setFeedbackCnt(new FeedbackCnt());
+                detail.getFeedbackCnt().setLikes(laws.getLike());
+                detail.getFeedbackCnt().setDislikes(laws.getDislike());
+                detail.setContent(laws.getContent());
+                detail.setResultType(ResultType.LAW.ordinal());
+                detail.setLink(laws.getUrl());
+                log.debug("Get search result detail success. Id: " + id);
+                return new ResponseEntity<>(new Response<>(true, detail, 0, ""), HttpStatus.OK);
+            } else if (type == ResultType.JUDGEMENT.ordinal()) {
+                return new ResponseEntity<>(new Response<>(false, null, HttpStatus.BAD_REQUEST.value(), "Not " +
+                        "implemented."), HttpStatus.BAD_REQUEST);
+            } else {
+                return new ResponseEntity<>(new Response<>(false, null, HttpStatus.BAD_REQUEST.value(), "Invalid " +
+                        "type."), HttpStatus.BAD_REQUEST);
             }
-            detail.setTitle(laws.getTitle());
-            detail.setSource(laws.getOffice());
-            detail.setPublishTime(laws.getPublish());
-            detail.setFeedbackCnt(new FeedbackCnt());
-            detail.getFeedbackCnt().setLikes(laws.getLike());
-            detail.getFeedbackCnt().setDislikes(laws.getDislike());
-            detail.setContent(laws.getContent());
-            detail.setResultType(ResultType.LAW.ordinal());
-            detail.setLink(laws.getUrl());
-            log.info("Get search result detail success. Id: " + id);
-            return new ResponseEntity<>(new Response<>(true, detail, 0, ""), HttpStatus.OK);
         } catch (Exception e) {
             log.error("Get search result detail error: " + e.getMessage());
+            return new ResponseEntity<>(new Response<>(false, null, HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                    "Internal server error."), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Operation(summary = "用户反馈", description = "用户对搜索结果的反馈，包括点赞和点踩。")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "成功"),
+            @ApiResponse(responseCode = "404", description = "内容不存在", content = @Content(schema =
+            @Schema(implementation = Response.class))),
+            @ApiResponse(responseCode = "500", description = "服务器内部错误", content = @Content(schema =
+            @Schema(implementation = Response.class)))
+    })
+    @PostMapping("/feedback")
+    public ResponseEntity<Response<Integer>> feedback(@RequestBody Feedback feedback, HttpServletRequest request,
+                                                      HttpServletResponse response) {
+        try {
+            // update in user's feedback
+            User user;
+            FeedbackType feedbackType;
+            try {
+                user = getCurrentUser(request, response, userService, rememberMeService);
+            } catch (Exception e) {
+                log.warn("Feedback error: User not found." + e.getMessage());
+                return new ResponseEntity<>(new Response<>(false, null, HttpStatus.UNAUTHORIZED.value(), "Not logged " +
+                        "in yet!"), HttpStatus.UNAUTHORIZED);
+            }
+            if (feedback.getFeedback()) {
+                if (user.getLikeAsList().contains(feedback.getId())) {
+                    feedbackType = FeedbackType.CANCEL_LIKE;
+                    List<String> like = user.getLikeAsList();
+                    like.remove(feedback.getId());
+                    user.setLikeFromList(like);
+                } else {
+                    feedbackType = FeedbackType.LIKE;
+                    List<String> like = user.getLikeAsList();
+                    like.add(feedback.getId());
+                    user.setLikeFromList(like);
+                }
+            } else {
+                if (user.getDislikeAsList().contains(feedback.getId())) {
+                    feedbackType = FeedbackType.CANCEL_DISLIKE;
+                    List<String> dislike = user.getDislikeAsList();
+                    dislike.remove(feedback.getId());
+                    user.setDislikeFromList(dislike);
+                } else {
+                    feedbackType = FeedbackType.DISLIKE;
+                    List<String> dislike = user.getDislikeAsList();
+                    dislike.add(feedback.getId());
+                    user.setDislikeFromList(dislike);
+                }
+            }
+            userService.updateById(user);
+
+            // update in Elasticsearch
+            if (feedback.getType() == ResultType.LAW.ordinal()) {
+                Laws laws = elasticsearchOperations.get(feedback.getId(), Laws.class);
+                if (laws == null) {
+                    log.warn("Feedback error: LawsData not found. Id: " + feedback.getId());
+                    return new ResponseEntity<>(new Response<>(false, null, HttpStatus.NOT_FOUND.value(),
+                            "LawsData not found."), HttpStatus.NOT_FOUND);
+                }
+                switch (feedbackType) {
+                    case LIKE -> laws.setLike(laws.getLike() + 1);
+                    case DISLIKE -> laws.setDislike(laws.getDislike() + 1);
+                    case CANCEL_LIKE -> laws.setLike(laws.getLike() - 1);
+                    case CANCEL_DISLIKE -> laws.setDislike(laws.getDislike() - 1);
+                }
+                elasticsearchOperations.save(laws);
+                log.debug("Feedback success. Id: " + feedback.getId());
+                return new ResponseEntity<>(new Response<>(true, feedbackType.ordinal(), 0, ""), HttpStatus.OK);
+            } else if (feedback.getType() == ResultType.JUDGEMENT.ordinal()) {
+                return new ResponseEntity<>(new Response<>(false, null, HttpStatus.BAD_REQUEST.value(), "Not " +
+                        "implemented."), HttpStatus.BAD_REQUEST);
+            } else {
+                return new ResponseEntity<>(new Response<>(false, null, HttpStatus.BAD_REQUEST.value(), "Invalid " +
+                        "type."), HttpStatus.BAD_REQUEST);
+            }
+        } catch (Exception e) {
+            log.error("Feedback error: " + e.getMessage());
             return new ResponseEntity<>(new Response<>(false, null, HttpStatus.INTERNAL_SERVER_ERROR.value(),
                     "Internal server error."), HttpStatus.INTERNAL_SERVER_ERROR);
         }
@@ -329,6 +467,17 @@ public class SearchController {
 
     public enum ResultType {
         LAW, JUDGEMENT
+    }
+
+    public enum FeedbackType {
+        LIKE, DISLIKE, CANCEL_LIKE, CANCEL_DISLIKE
+    }
+
+    @Data
+    public static class Feedback {
+        private String id;
+        private Integer type;
+        private Boolean feedback;
     }
 
     @Data
@@ -356,6 +505,7 @@ public class SearchController {
             private Integer resultType;
             private String source;
             private FeedbackCnt feedbackCnt;
+            private Float score;
         }
     }
 

--- a/backend/src/main/java/team/semg04/themirroroflaw/user/PersonalController.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/user/PersonalController.java
@@ -1,0 +1,77 @@
+package team.semg04.themirroroflaw.user;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import team.semg04.themirroroflaw.Response;
+import team.semg04.themirroroflaw.user.entity.User;
+import team.semg04.themirroroflaw.user.service.UserService;
+import team.semg04.themirroroflaw.user.utils.RememberMeService;
+
+import java.util.List;
+
+import static team.semg04.themirroroflaw.user.UserController.getCurrentUser;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/personal")
+@Tag(name = "Personal", description = "个性化相关内容")
+public class PersonalController {
+    private UserService userService;
+
+    private RememberMeService rememberMeService;
+
+    @Autowired
+    public void setUserService(UserService userService) {
+        this.userService = userService;
+    }
+
+    @Autowired
+    public void setRememberMeService(RememberMeService rememberMeService) {
+        this.rememberMeService = rememberMeService;
+    }
+
+    @Operation(summary = "获取个人历史记录", description = "获取个人历史记录")
+    @Parameter(name = "reqNumber", description = "请求的历史记录数量")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "成功"),
+            @ApiResponse(responseCode = "401", description = "未登录", content = @Content(schema =
+            @Schema(implementation = Response.class))),
+            @ApiResponse(responseCode = "500", description = "服务器内部错误", content = @Content(schema =
+            @Schema(implementation = Response.class)))
+    })
+    @GetMapping("/history")
+    public ResponseEntity<Response<List<String>>> history(@RequestParam Integer reqNumber, HttpServletRequest request
+            , HttpServletResponse response) {
+        try {
+            try {
+                User user = getCurrentUser(request, response, userService, rememberMeService);
+                List<String> history = List.copyOf(user.getHistoryAsSet());
+                log.debug("Get personal history: " + history);
+                return new ResponseEntity<>(new Response<>(true, history.subList(0, Math.min(history.size(), reqNumber))
+                        , 0, "Success."), HttpStatus.OK);
+            } catch (Exception e) {
+                log.warn("Get personal history error: User not found." + e.getMessage());
+                return new ResponseEntity<>(new Response<>(false, null, 1, "Not logged in yet!"),
+                        HttpStatus.UNAUTHORIZED);
+            }
+        } catch (Exception e) {
+            log.error("Get personal history error: ", e);
+            return ResponseEntity.status(500).body(new Response<>(false, null, 500, "Internal server error."));
+        }
+    }
+}

--- a/backend/src/main/java/team/semg04/themirroroflaw/user/entity/User.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/user/entity/User.java
@@ -3,9 +3,15 @@ package team.semg04.themirroroflaw.user.entity;
 import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.LinkedHashSet;
+import java.util.List;
 
 @Data
+@Slf4j
 @TableName("users")
 public class User {
     @TableId(value = "id", type = IdType.AUTO)
@@ -13,7 +19,61 @@ public class User {
     String username;
     String email;
     String password;
-    String history;
-    String setting;
-    String feedback;
+    byte[] history;
+    byte[] feedbackLike;
+    byte[] feedbackDislike;
+
+    public LinkedHashSet<String> getHistoryAsSet() {
+        try {
+            return new ObjectMapper().readValue(new String(history), LinkedHashSet.class);
+        } catch (Exception e) {
+            log.error("User getHistory error: ", e);
+            return null;
+        }
+    }
+
+    public void setHistoryFromSet(LinkedHashSet<String> history) {
+        try {
+            this.history = new ObjectMapper().writeValueAsBytes(history);
+        } catch (Exception e) {
+            log.error("User setHistory error: ", e);
+            this.history = null;
+        }
+    }
+
+    public List<String> getLikeAsList() {
+        try {
+            return new ObjectMapper().readValue(new String(feedbackLike), List.class);
+        } catch (Exception e) {
+            log.error("User getHistory error: ", e);
+            return null;
+        }
+    }
+
+    public void setLikeFromList(List<String> feedbackLike) {
+        try {
+            this.feedbackLike = new ObjectMapper().writeValueAsBytes(feedbackLike);
+        } catch (Exception e) {
+            log.error("User setHistory error: ", e);
+            this.feedbackLike = null;
+        }
+    }
+
+    public List<String> getDislikeAsList() {
+        try {
+            return new ObjectMapper().readValue(new String(feedbackDislike), List.class);
+        } catch (Exception e) {
+            log.error("User getHistory error: ", e);
+            return null;
+        }
+    }
+
+    public void setDislikeFromList(List<String> feedbackDislike) {
+        try {
+            this.feedbackDislike = new ObjectMapper().writeValueAsBytes(feedbackDislike);
+        } catch (Exception e) {
+            log.error("User setHistory error: ", e);
+            this.feedbackDislike = null;
+        }
+    }
 }

--- a/backend/src/main/resources/application_template.properties
+++ b/backend/src/main/resources/application_template.properties
@@ -31,5 +31,5 @@ springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.default-consumes-media-type=application/json
 springdoc.default-produces-media-type=application/json
 #-----FOR DEBUGGING-----#
-#logging.level.tracer=TRACE
+logging.level.team.semg04.themirroroflaw=DEBUG
 #-----------------------#


### PR DESCRIPTION
【该PR修改了后端配置文件，增加调试信息输出配置（最后一行），可按需添加】
【数据库中用户数据已被清空，若需测试请重新注册】
对接口做了如下改动：
## 搜索结果列表展示

返回的每项结果中新增score字段，表示匹配度，供后端排序使用（前端可忽略此返回，应该无需修改）。

## 结果详情展示

需要额外的参数：`type: Integer`，表示文档类型。

## 用户搜索历史显示

接口设计与设计文档相同，该接口可指定所需的历史条数。
此外，在登录和获取用户信息时也会返回history，且会返回所有内容。

## 获取用户信息（包括登录时返回的用户信息）

返回内容新增history、like和dislike三个数组，完整结构体如下。
![图片](https://github.com/jiangmizzz/The-Mirror-of-Law/assets/58109197/d5808211-4873-4eb1-bcd3-fc48abd33191)


## 用户反馈

Response中的data改为一个整数，表示成功操作的状态（若失败则data为null，这点与其它接口相同）。
状态定义如下，用0~5表示，即点赞、点踩、取消点赞、取消点踩、点赞变为点踩、点踩变为点赞。
![图片](https://github.com/jiangmizzz/The-Mirror-of-Law/assets/58109197/4371a0d5-7d60-4c67-9cfd-38fa926a53b2)

---
以下为原commit信息：

1. 优化日志记录等级，修改配置文件，增加调试输出。
2. 修复获取知识图谱接口children可能返回空数组的问题。
3. 修复获取知识图谱接口depth深度过大空循环不退出的bug。
4. 搜索结果列表展示接口返回内容新增score项（前端可忽略此项），并且结果列表将根据score, date排序，为后续搜索类型扩展准备。
5. 实现搜索历史记录功能，搜索时若用户已登录则记录历史。
6. 修改结果详情展示接口参数，新增type参数表示文档类型，为后续搜索类型扩展做准备。
7. 新增用户反馈接口，与设计时的接口略有不同，会返回整数代表操作状态。
8. 修改获取用户信息接口与登录接口，返回的用户信息内容中新增history、like、dislike。
9. 修改User表设计，实现history、feedbackLike、feedbackDislike的序列化和反序列化。
10. 新增获取个人历史记录接口，返回指定的历史记录数量。