### PR TITLE
添加了详情页的用户反馈模块

### DIFF
--- a/frontend/src/stores/userStore.tsx
+++ b/frontend/src/stores/userStore.tsx
@@ -86,26 +86,34 @@ export const useUserStore = create<userState>()((set) => ({
         const index: number = state.likes.indexOf(id);
         return {
           //后端无误的话这个index一定不会是-1
-          likes: state.likes.splice(index, 1),
+          likes: state.likes
+            .slice(0, index)
+            .concat(state.likes.slice(index + 1)),
         };
       } else if (actionCode == 3) {
         //取消点踩
         const index: number = state.dislikes.indexOf(id);
         return {
-          dislikes: state.dislikes.splice(index, 1),
+          dislikes: state.dislikes
+            .slice(0, index)
+            .concat(state.dislikes.slice(index + 1)),
         };
       } else if (actionCode == 4) {
         //点赞变为点踩
         const index: number = state.likes.indexOf(id);
         return {
-          likes: state.likes.splice(index, 1),
+          likes: state.likes
+            .slice(0, index)
+            .concat(state.likes.slice(index + 1)),
           dislikes: [...state.dislikes, id],
         };
       } else {
         //点踩变为点赞
         const index: number = state.dislikes.indexOf(id);
         return {
-          dislikes: state.dislikes.splice(index, 1),
+          dislikes: state.dislikes
+            .slice(0, index)
+            .concat(state.dislikes.slice(index + 1)),
           likes: [...state.likes, id],
         };
       }


### PR DESCRIPTION
基本实现了搜索结果页的用户反馈功能（欢迎找bug）
> 但是实现过程中发现一个问题：
我在post请求完后，重新获取点赞数（也就是刷新请求数据，对于使用swr获取的列表形式的数据，这应该是最方便的更新方法）时，如果立即刷新则只能获取上一次（反馈前）的数据，只有手动设置了一定的时间间隔后刷新才能获得正确的结果，实现如下：
![image](https://github.com/jiangmizzz/The-Mirror-of-Law/assets/107181425/f1ea5bc0-2f1f-45b4-8027-fb49d571ef38)

我一开始以为是我的状态更新或者页面重新渲染有误，检查了很久也没有头绪，因为反馈的接口请求成功就没有往数据请求失败的方面想……
想问一下这是数据库更新不及时导致的吗？后端有没有什么规避的方法呢？😟