### PR TITLE
重构搜索实体与搜索类，实现相关内容推荐接口

### DIFF
--- a/backend/src/main/java/team/semg04/themirroroflaw/search/SearchController.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/search/SearchController.java
@@ -48,6 +48,20 @@ public class SearchController {
 
     private RememberMeService rememberMeService;
 
+    private static void validatePageable(Integer pageSize, Integer pageNumber) {
+        // Check parameters
+        if (pageSize <= 0 || pageSize > 50) {
+            log.warn("Get search result list error: Invalid pageSize. pageSize: " + pageSize);
+            throw new IllegalArgumentException("Invalid pageSize. PageSize should be in range [1, 50].");
+
+        }
+        if (pageNumber < 0 || pageNumber + pageSize > 10000) {
+            log.warn("Get search result list error: Invalid pageNumber. pageNumber: " + pageNumber);
+            throw new IllegalArgumentException("Invalid pageNumber. PageNumber should be in range [0, 10000 - " +
+                    "pageSize].");
+        }
+    }
+
     @Autowired
     public void setUserService(UserService userService) {
         this.userService = userService;
@@ -65,132 +79,150 @@ public class SearchController {
     }
 
     public void init() {
-        Script allScript = Script.builder().withId("search_by_all").withLanguage("mustache")
-                .withSource("""
-                        {
-                          "_source": {
-                            "includes": ["id","type","title","date","source","like","dislike"]
-                          },
-                          "highlight": {
-                            "boundary_chars": "{{{boundary_chars}}}",
-                            "boundary_scanner_locale": "zh-cn",
-                            "pre_tags": [""],
-                            "post_tags": [""],
-                            "fields": {
-                              "content": {}
-                            }
-                          },
-                          "post_filter": {
-                            "range": {
-                              "date": {
-                                "gte": "{{{startTime}}}",
-                                "lte": "{{{endTime}}}"
-                              }
-                            }
-                          },
-                          "query": {
-                            "bool": {
-                              "must": [
-                                        {
-                                          "multi_match": {
-                                            "query": "{{{input}}}",
-                                            "fields": ["content", "title^3"],
-                                            "analyzer": "ik_smart"
-                                          }
-                                        },
-                                        {
-                                          "terms": {
-                                            "type": {{{type}}}
-                                          }
-                                        }
-                                      ],
-                              "should": {
+        Script allScript = Script.builder().withId("search_by_all").withLanguage("mustache").withSource("""
+                {
+                  "_source": {
+                    "includes": ["id","type","title","date","source","like","dislike"]
+                  },
+                  "highlight": {
+                    "boundary_chars": "{{{boundary_chars}}}",
+                    "boundary_scanner_locale": "zh-cn",
+                    "pre_tags": [""],
+                    "post_tags": [""],
+                    "fields": {
+                      "content": {}
+                    }
+                  },
+                  "post_filter": {
+                    "range": {
+                      "date": {
+                        "gte": "{{{startTime}}}",
+                        "lte": "{{{endTime}}}"
+                      }
+                    }
+                  },
+                  "query": {
+                    "bool": {
+                      "must": [
+                                {
                                   "multi_match": {
-                                  "query": "中华人民共和国",
-                                  "fields": ["title"],
-                                  "analyzer": "ik_smart",
-                                  "boost": 2
+                                    "query": "{{{input}}}",
+                                    "fields": ["content", "title^3"],
+                                    "analyzer": "ik_smart"
                                   }
-                              }
-                            }
-                          },
-                          "size": {{{size}}},
-                          "from": {{{from}}}
-                        }""").build();
-        Script singleScript = Script.builder().withId("search_by_single").withLanguage("mustache")
-                .withSource("""
-                        {
-                          "_source": {
-                            "includes": ["id","type","title","date","source","like","dislike"]
-                          },
-                          "highlight": {
-                            "boundary_chars": "{{{boundary_chars}}}",
-                            "boundary_scanner_locale": "zh-cn",
-                            "pre_tags": [""],
-                            "post_tags": [""],
-                            "fields": {
-                              "content": {
-                                "highlight_query": {
-                                  "bool": {
-                                    "must": [
-                                        {
-                                          "multi_match": {
-                                            "query": "{{{input}}}",
-                                            "fields": ["content"],
-                                            "analyzer": "ik_smart"
-                                          }
-                                        },
-                                        {
-                                          "terms": {
-                                            "type": {{{type}}}
-                                          }
-                                        }
-                                      ]
+                                },
+                                {
+                                  "terms": {
+                                    "type": {{{type}}}
                                   }
                                 }
-                              }
-                            }
-                          },
-                          "post_filter": {
-                            "range": {
-                              "date": {
-                                "gte": "{{{startTime}}}",
-                                "lte": "{{{endTime}}}"
-                              }
-                            }
-                          },
-                          "query": {
-                            "bool": {
-                              "must": [
-                                        {
-                                          "multi_match": {
-                                            "query": "{{{input}}}",
-                                            "fields": ["{{{field}}}"],
-                                            "analyzer": "ik_smart"
-                                          }
-                                        },
-                                        {
-                                          "terms": {
-                                            "type": {{{type}}}
-                                          }
-                                        }
-                                      ],
-                              "should": {
+                              ],
+                      "should": {
+                          "multi_match": {
+                          "query": "中华人民共和国",
+                          "fields": ["title"],
+                          "analyzer": "ik_smart",
+                          "boost": 2
+                          }
+                      }
+                    }
+                  },
+                  "size": {{{size}}},
+                  "from": {{{from}}}
+                }""").build();
+        Script singleScript = Script.builder().withId("search_by_single").withLanguage("mustache").withSource("""
+                {
+                  "_source": {
+                    "includes": ["id","type","title","date","source","like","dislike"]
+                  },
+                  "highlight": {
+                    "boundary_chars": "{{{boundary_chars}}}",
+                    "boundary_scanner_locale": "zh-cn",
+                    "pre_tags": [""],
+                    "post_tags": [""],
+                    "fields": {
+                      "content": {
+                        "highlight_query": {
+                          "bool": {
+                            "must": [
+                                {
                                   "multi_match": {
-                                  "query": "中华人民共和国",
-                                  "fields": ["title"],
-                                  "analyzer": "ik_smart",
-                                  "boost": 2
+                                    "query": "{{{input}}}",
+                                    "fields": ["content"],
+                                    "analyzer": "ik_smart"
                                   }
-                              }
-                            }
-                          },
-                          "size": {{{size}}},
-                          "from": {{{from}}}
-                        }""").build();
+                                },
+                                {
+                                  "terms": {
+                                    "type": {{{type}}}
+                                  }
+                                }
+                              ]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "post_filter": {
+                    "range": {
+                      "date": {
+                        "gte": "{{{startTime}}}",
+                        "lte": "{{{endTime}}}"
+                      }
+                    }
+                  },
+                  "query": {
+                    "bool": {
+                      "must": [
+                                {
+                                  "multi_match": {
+                                    "query": "{{{input}}}",
+                                    "fields": ["{{{field}}}"],
+                                    "analyzer": "ik_smart"
+                                  }
+                                },
+                                {
+                                  "terms": {
+                                    "type": {{{type}}}
+                                  }
+                                }
+                              ],
+                      "should": {
+                          "multi_match": {
+                          "query": "中华人民共和国",
+                          "fields": ["title"],
+                          "analyzer": "ik_smart",
+                          "boost": 2
+                          }
+                      }
+                    }
+                  },
+                  "size": {{{size}}},
+                  "from": {{{from}}}
+                }""").build();
+        Script moreLikeThis = Script.builder().withId("search_more_like_this").withLanguage("mustache").withSource("""
+                {
+                   "_source": {
+                     "includes": ["id","title"]
+                   },
+                   "query": {
+                     "more_like_this": {
+                       "fields": ["title","content"],
+                       "like": [
+                         {
+                           "_index": "mirror-of-law",
+                           "_id": "{{{id}}}"
+                         }
+                       ]
+                     }
+                   },
+                   "size": {{{size}}},
+                   "from": {{{from}}}
+                 }""").build();
         try {
             elasticsearchOperations.deleteScript("search_by_all");
             elasticsearchOperations.deleteScript("search_by_single");
+            elasticsearchOperations.deleteScript("search_more_like_this");
             log.debug("Delete script success.");
         } catch (Exception e) {
             log.error("Delete script error: " + e.getMessage());
@@ -198,6 +230,7 @@ public class SearchController {
         try {
             elasticsearchOperations.putScript(allScript);
             elasticsearchOperations.putScript(singleScript);
+            elasticsearchOperations.putScript(moreLikeThis);
             log.debug("Put script success.");
         } catch (Exception e) {
             log.error("Put script error: " + e.getMessage());
@@ -205,51 +238,30 @@ public class SearchController {
         }
     }
 
-    @Operation(summary = "搜索结果列表展示", description =
-            "对于给定的输入量和筛选条件（包括搜索类型、高级搜索中的规定），返回以合适的顺序完成排序的搜索结果列表，为方便查看，采用分页展示。")
-    @Parameters({
-            @Parameter(name = "input", description = "用户在输入框中输入的内容"),
-            @Parameter(name = "searchType", description = "搜索类型"),
-            @Parameter(name = "resultType", description = "结果类型"),
-            @Parameter(name = "startTime", description = "起始时间，年份≤-9999表示无限制"),
-            @Parameter(name = "endTime", description = "终止时间，年份≥9999表示无限制"),
-            @Parameter(name = "pageSize", description = "每页条数"),
-            @Parameter(name = "pageNumber", description = "第x页，从0开始")
-    })
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "成功"),
-            @ApiResponse(responseCode = "400", description = "请求参数错误", content = @Content(schema =
-            @Schema(implementation = Response.class))),
+    @Operation(summary = "搜索结果列表展示", description = "对于给定的输入量和筛选条件（包括搜索类型、高级搜索中的规定），返回以合适的顺序完成排序的搜索结果列表，为方便查看，采用分页展示。")
+    @Parameters({@Parameter(name = "input", description = "用户在输入框中输入的内容"), @Parameter(name = "searchType",
+            description = "搜索类型"), @Parameter(name = "resultType", description = "结果类型"), @Parameter(name =
+            "startTime", description = "起始时间，年份≤-9999表示无限制"), @Parameter(name = "endTime", description =
+            "终止时间，年份≥9999表示无限制"), @Parameter(name = "pageSize", description = "每页条数"), @Parameter(name = "pageNumber"
+            , description = "第x页，从0开始")})
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "成功"), @ApiResponse(responseCode = "400",
+            description = "请求参数错误", content = @Content(schema = @Schema(implementation = Response.class))),
             @ApiResponse(responseCode = "500", description = "服务器内部错误", content = @Content(schema =
-            @Schema(implementation = Response.class)))
-    })
+            @Schema(implementation = Response.class)))})
     @GetMapping("/list")
     public ResponseEntity<Response<SearchList>> searchLaws(@RequestParam(name = "input") String input,
                                                            @RequestParam(name = "searchType", required = false,
                                                                    defaultValue = "0") Integer searchTypeInt,
-                                                           @RequestParam(name = "resultType") List<Integer> resultTypeInt,
-                                                           @RequestParam(name = "startTime", required = false,
-                                                                   defaultValue = "-9999-01-01") LocalDate startTime,
-                                                           @RequestParam(name = "endTime", required = false,
-                                                                   defaultValue = "9999-12-31") LocalDate endTime,
-                                                           @RequestParam(name = "pageSize", required = false,
-                                                                   defaultValue = "10") Integer pageSize,
-                                                           @RequestParam(name = "pageNumber", required = false,
-                                                                   defaultValue = "0") Integer pageNumber,
-                                                           HttpServletRequest request, HttpServletResponse response) {
+                                                           @RequestParam(name = "resultType") List<Integer> resultTypeInt, @RequestParam(name = "startTime", required = false, defaultValue = "-9999-01-01") LocalDate startTime, @RequestParam(name = "endTime", required = false, defaultValue = "9999-12-31") LocalDate endTime, @RequestParam(name = "pageSize", required = false, defaultValue = "10") Integer pageSize, @RequestParam(name = "pageNumber", required = false, defaultValue = "0") Integer pageNumber, HttpServletRequest request, HttpServletResponse response) {
         try {
-            // Check parameters
-            if (pageSize <= 0 || pageSize > 50) {
-                log.warn("Get search result list error: Invalid pageSize. pageSize: " + pageSize);
+            try {
+                validatePageable(pageSize, pageNumber);
+            } catch (IllegalArgumentException e) {
+                log.warn("Get search result list error: " + e.getMessage());
                 return new ResponseEntity<>(new Response<>(false, null, HttpStatus.BAD_REQUEST.value(),
-                        "Invalid pageSize. PageSize should be in range [1, 50]."), HttpStatus.BAD_REQUEST);
+                        e.getMessage()), HttpStatus.BAD_REQUEST);
             }
-            if (pageNumber < 0 || pageNumber + pageSize > 10000) {
-                log.warn("Get search result list error: Invalid pageNumber. pageNumber: " + pageNumber);
-                return new ResponseEntity<>(new Response<>(false, null, HttpStatus.BAD_REQUEST.value(),
-                        "Invalid pageNumber. PageNumber should be in range [0, 10000 - pageSize]."),
-                        HttpStatus.BAD_REQUEST);
-            }
+
             SearchType searchType = SearchType.values()[searchTypeInt];
 
             // Initialize result list
@@ -269,18 +281,11 @@ public class SearchController {
             };
             SearchHits<MirrorOfLaw> searchResult;
             if (searchType == SearchType.ALL) {
-                searchResult = elasticsearchOperations.search(SearchTemplateQuery.builder()
-                        .withId("search_by_all").withParams(Map.of("input", input, "startTime",
-                                startTime.toString(), "endTime", endTime.toString(), "size",
-                                pageable.getPageSize(), "from", pageable.getOffset(), "boundary_chars",
-                                boundary_chars, "type", resultType)).build(), MirrorOfLaw.class);
+                searchResult =
+                        elasticsearchOperations.search(SearchTemplateQuery.builder().withId("search_by_all").withParams(Map.of("input", input, "startTime", startTime.toString(), "endTime", endTime.toString(), "size", pageable.getPageSize(), "from", pageable.getOffset(), "boundary_chars", boundary_chars, "type", resultType)).build(), MirrorOfLaw.class);
             } else {
-                searchResult = elasticsearchOperations.search(SearchTemplateQuery.builder()
-                        .withId("search_by_single").withParams(Map.of("input", input, "field",
-                                fields, "startTime", startTime.toString(),
-                                "endTime", endTime.toString(), "size", pageable.getPageSize(), "from",
-                                pageable.getOffset(), "boundary_chars", boundary_chars, "type",
-                                resultType)).build(), MirrorOfLaw.class);
+                searchResult =
+                        elasticsearchOperations.search(SearchTemplateQuery.builder().withId("search_by_single").withParams(Map.of("input", input, "field", fields, "startTime", startTime.toString(), "endTime", endTime.toString(), "size", pageable.getPageSize(), "from", pageable.getOffset(), "boundary_chars", boundary_chars, "type", resultType)).build(), MirrorOfLaw.class);
             }
             searchList.setTotal((int) searchResult.getTotalHits());
             for (SearchHit<MirrorOfLaw> data : searchResult) {
@@ -337,27 +342,21 @@ public class SearchController {
     }
 
     @Operation(summary = "结果详情展示", description = "用户点击搜索结果列表中的某一条后，即可进入详情页查看详细内容，这些内容应以合适的格式整理并呈现。")
-    @Parameters({
-            @Parameter(name = "id", description = "内容的id"),
-            @Parameter(name = "type", description = "内容的类型")
-    })
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "成功"),
-            @ApiResponse(responseCode = "404", description = "内容不存在", content = @Content(schema =
-            @Schema(implementation = Response.class))),
+    @Parameters({@Parameter(name = "id", description = "内容的id"), @Parameter(name = "type", description = "内容的类型")})
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "成功"), @ApiResponse(responseCode = "404",
+            description = "内容不存在", content = @Content(schema = @Schema(implementation = Response.class))),
             @ApiResponse(responseCode = "500", description = "服务器内部错误", content = @Content(schema =
-            @Schema(implementation = Response.class)))
-    })
+            @Schema(implementation = Response.class)))})
     @GetMapping("/detail")
-    public ResponseEntity<Response<Detail>> searchDetail(@RequestParam(name = "id") String id,
-                                                         @RequestParam(name = "type") Integer type) {
+    public ResponseEntity<Response<Detail>> searchDetail(@RequestParam(name = "id") String id, @RequestParam(name =
+            "type") Integer type) {
         try {
             Detail detail = new Detail();
             MirrorOfLaw document = elasticsearchOperations.get(id, MirrorOfLaw.class);
             if (document == null) {
                 log.warn("Get search result detail error: Document not found. Id: " + id);
                 return new ResponseEntity<>(new Response<>(false, null, HttpStatus.NOT_FOUND.value(),
-                        "Document not found."), HttpStatus.NOT_FOUND);
+                        "Document not " + "found."), HttpStatus.NOT_FOUND);
             }
             detail.setTitle(document.getTitle());
             detail.setSource(document.getSource());
@@ -378,13 +377,10 @@ public class SearchController {
     }
 
     @Operation(summary = "用户反馈", description = "用户对搜索结果的反馈，包括点赞和点踩。")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "成功"),
-            @ApiResponse(responseCode = "404", description = "内容不存在", content = @Content(schema =
-            @Schema(implementation = Response.class))),
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "成功"), @ApiResponse(responseCode = "404",
+            description = "内容不存在", content = @Content(schema = @Schema(implementation = Response.class))),
             @ApiResponse(responseCode = "500", description = "服务器内部错误", content = @Content(schema =
-            @Schema(implementation = Response.class)))
-    })
+            @Schema(implementation = Response.class)))})
     @PostMapping("/feedback")
     public synchronized ResponseEntity<Response<Integer>> feedback(@RequestBody Feedback feedback,
                                                                    HttpServletRequest request,
@@ -397,8 +393,8 @@ public class SearchController {
                 user = getCurrentUser(request, response, userService, rememberMeService);
             } catch (Exception e) {
                 log.warn("Feedback error: User not found." + e.getMessage());
-                return new ResponseEntity<>(new Response<>(false, null, HttpStatus.UNAUTHORIZED.value(), "Not logged " +
-                        "in yet!"), HttpStatus.UNAUTHORIZED);
+                return new ResponseEntity<>(new Response<>(false, null, HttpStatus.UNAUTHORIZED.value(), "Not logged "
+                        + "in yet!"), HttpStatus.UNAUTHORIZED);
             }
             if (feedback.getFeedback()) {
                 if (user.getLikeAsList().contains(feedback.getId())) {
@@ -448,7 +444,7 @@ public class SearchController {
             if (document == null) {
                 log.warn("Feedback error: LawsData not found. Id: " + feedback.getId());
                 return new ResponseEntity<>(new Response<>(false, null, HttpStatus.NOT_FOUND.value(),
-                        "LawsData not found."), HttpStatus.NOT_FOUND);
+                        "LawsData not " + "found."), HttpStatus.NOT_FOUND);
             }
             switch (feedbackType) {
                 case LIKE -> document.setLike(document.getLike() + 1);
@@ -474,6 +470,57 @@ public class SearchController {
                     "Internal server error."), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
+
+    @Operation(summary = "相关内容推荐", description = "在搜索结果详情页中，根据当前内容推荐相关内容。")
+    @Parameters({@Parameter(name = "id", description = "内容的id"), @Parameter(name = "type", description = "内容的类型"),
+            @Parameter(name = "pageSize", description = "每页条数"), @Parameter(name = "pageNumber", description =
+            "第x" + "页，从0开始")})
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "成功"), @ApiResponse(responseCode = "404",
+            description = "内容不存在", content = @Content(schema = @Schema(implementation = Response.class))),
+            @ApiResponse(responseCode = "500", description = "服务器内部错误", content = @Content(schema =
+            @Schema(implementation = Response.class)))})
+    @GetMapping("/related")
+    public ResponseEntity<Response<RelatedList>> related(@RequestParam(name = "id") String id, @RequestParam(name =
+            "type") Integer type, @RequestParam(name = "pageSize", required = false, defaultValue = "10") Integer pageSize, @RequestParam(name = "pageNumber", required = false, defaultValue = "0") Integer pageNumber) {
+        try {
+            try {
+                validatePageable(pageSize, pageNumber);
+            } catch (IllegalArgumentException e) {
+                log.warn("Get related list error: " + e.getMessage());
+                return new ResponseEntity<>(new Response<>(false, null, HttpStatus.BAD_REQUEST.value(),
+                        e.getMessage()), HttpStatus.BAD_REQUEST);
+            }
+
+            RelatedList relatedList = new RelatedList();
+            relatedList.setLinks(new ArrayList<>());
+            relatedList.setTotal(0);
+
+            Pageable pageable = Pageable.ofSize(pageSize).withPage(pageNumber);
+            MirrorOfLaw document = elasticsearchOperations.get(id, MirrorOfLaw.class);
+            if (document == null) {
+                log.warn("Get related list error: Document not found. Id: " + id);
+                return new ResponseEntity<>(new Response<>(false, null, HttpStatus.NOT_FOUND.value(),
+                        "Document not " + "found."), HttpStatus.NOT_FOUND);
+            }
+            SearchHits<MirrorOfLaw> lawsData = elasticsearchOperations.search(SearchTemplateQuery.builder().withId(
+                    "search_more_like_this").withParams(Map.of("id", id, "size", pageable.getPageSize(), "from",
+                    pageable.getOffset())).build(), MirrorOfLaw.class);
+            relatedList.setTotal((int) lawsData.getTotalHits());
+            for (SearchHit<MirrorOfLaw> data : lawsData) {
+                Related related = new Related();
+                related.setId(data.getContent().getId());
+                related.setTitle(data.getContent().getTitle());
+                relatedList.getLinks().add(related);
+            }
+            log.debug("Get related list success. Total: " + lawsData.getTotalHits());
+            return new ResponseEntity<>(new Response<>(true, relatedList, 0, ""), HttpStatus.OK);
+        } catch (Exception e) {
+            log.error("Get related list error: " + e.getMessage());
+            return new ResponseEntity<>(new Response<>(false, null, HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                    "Internal server error."), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
 
     public enum SearchType {
         ALL, TITLE, SOURCE
@@ -527,5 +574,17 @@ public class SearchController {
     public static class FeedbackCnt {
         private Integer likes;
         private Integer dislikes;
+    }
+
+    @Data
+    public static class Related {
+        private String id;
+        private String title;
+    }
+
+    @Data
+    public static class RelatedList {
+        private List<Related> links;
+        private Integer total;
     }
 }

--- a/backend/src/main/java/team/semg04/themirroroflaw/search/WordFrequencyController.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/search/WordFrequencyController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import team.semg04.themirroroflaw.Response;
-import team.semg04.themirroroflaw.search.entity.Laws;
+import team.semg04.themirroroflaw.search.entity.MirrorOfLaw;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,7 +54,7 @@ public class WordFrequencyController {
         List<Map<String, Object>> wordFrequencyList = new ArrayList<>();
         try {
             if(typeInt == DocumentType.LAW.ordinal()) {
-                Laws laws = elasticsearchOperations.get(id, Laws.class);
+                MirrorOfLaw laws = elasticsearchOperations.get(id, MirrorOfLaw.class);
                 if (laws == null) {
                     log.error("Get search result detail error: LawsData not found. Id: " + id);
                     return new ResponseEntity<>(new Response<>(false, null, HttpStatus.NOT_FOUND.value(),

--- a/backend/src/main/java/team/semg04/themirroroflaw/search/entity/MirrorOfLaw.java
+++ b/backend/src/main/java/team/semg04/themirroroflaw/search/entity/MirrorOfLaw.java
@@ -8,10 +8,9 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
 
 import java.time.LocalDate;
 
-
 @Data
-@Document(indexName = "laws")
-public class Laws {
+@Document(indexName = "mirror-of-law")
+public class MirrorOfLaw {
     @Id
     private String id;
 
@@ -19,18 +18,14 @@ public class Laws {
     private String title;
     @Field(name = "level", type = FieldType.Text)
     private String level;
-    @Field(name = "office", type = FieldType.Keyword)
-    private String office;
-    @Field(name = "publish", type = FieldType.Date)
-    private LocalDate publish;
-    @Field(name = "expiry", type = FieldType.Date)
-    private LocalDate expiry;
-    @Field(name = "type", type = FieldType.Binary)
-    private String type;
-    @Field(name = "status", type = FieldType.Byte)
-    private Byte status;
+    @Field(name = "source", type = FieldType.Text)
+    private String source;
+    @Field(name = "date", type = FieldType.Date)
+    private LocalDate date;
     @Field(name = "content", type = FieldType.Text)
     private String content;
+    @Field(name = "type", type = FieldType.Integer)
+    private Integer type;
     @Field(name = "url", type = FieldType.Binary)
     private String url;
     @Field(name = "like", type = FieldType.Integer)


### PR DESCRIPTION
【由于底层重构，请对AI模块和词云模块进行回归测试】

目前，detail和related两个接口的type参数会被后端忽略，没有实际作用。

相关内容推荐接口如下（与设计报告***不符***）：

GET /search/related
Request:
```yaml
id: string,
type: number,
pageSize: number,	// 每页条数
pageNum: number	// 第x页，从0开始
```
Response:
```yaml
links: List<Related>,
total: number	// 相关内容总数
```

其中，Related定义如下
```yaml
id: string,
title: string
```

---

以下为原commit信息：
1. 重构搜索实体，删除法律法规实体，新增统一实体。
2. 重构搜索部分代码，以适配实体变化。
3. 实现相关内容推荐接口。