### PR TITLE
图谱中心节点描述文本可换行

### DIFF
--- a/frontend/src/pages/results/component/KnowledgeMap.tsx
+++ b/frontend/src/pages/results/component/KnowledgeMap.tsx
@@ -9,6 +9,7 @@ import {
   MinusOutlined,
 } from "@ant-design/icons";
 import "./KnowledgeMap.css";
+import Paragraph from "antd/es/typography/Paragraph";
 
 interface KnowledgeMapProps {
   center: NodeInfo; //中心词条
@@ -114,7 +115,10 @@ export default function KnowledgeMap(props: KnowledgeMapProps) {
         </Tooltip>
       </Space>
       <Divider style={{ margin: "1em 0" }}></Divider>
-      <div>{props.desc}</div>
+      {props.desc.split("\n").map((para) => {
+        return <Paragraph>{para}</Paragraph>;
+      })}
+      {/* <div>{props.desc}</div> */}
       <div
         style={{
           //   background: "#0E1155",


### PR DESCRIPTION
fix: add line-wrap in knowledgemap desc